### PR TITLE
 fix: 修改线程控制块中的标志位长度

### DIFF
--- a/cmsis_rtthread.c
+++ b/cmsis_rtthread.c
@@ -936,7 +936,7 @@ uint32_t osThreadFlagsSet(osThreadId_t thread_id, uint32_t flags)
                 thread_cb->flag_set &= ~thread_cb->thread.event_set;
 
             /* resume thread, and thread list breaks out */
-            rt_thread_resume(rt_thread_self());
+            rt_thread_resume(&(thread_cb->thread));
             need_schedule = RT_TRUE;
         }
     }

--- a/cmsis_rtthread.h
+++ b/cmsis_rtthread.h
@@ -45,10 +45,10 @@ extern "C" {
 
 typedef struct
 {
-    rt_uint8_t flags;
+    rt_uint32_t flags;
     struct rt_thread thread;
     rt_sem_t joinable_sem;    ///< semaphore for joinable thread
-    rt_uint8_t flag_set;      ///< thread flag set
+    rt_uint32_t flag_set;     ///< thread flag set
     rt_uint8_t prio;
 }thread_cb_t;
 


### PR DESCRIPTION
以下几个都使用了32位
osThreadFlagsSet
osThreadFlagsClear
osThreadFlagsGet
osThreadFlagsWait

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thread flag resumption logic to properly resume the waiting thread instead of the current thread.

* **Improvements**
  * Expanded thread flag storage capacity for enhanced flag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->