### PR TITLE
fix(cmsis_rtthread): 防止事件标志设置在未保护状态下更改

### DIFF
--- a/cmsis_rtthread.c
+++ b/cmsis_rtthread.c
@@ -1367,7 +1367,7 @@ uint32_t osEventFlagsSet(osEventFlagsId_t ef_id, uint32_t flags)
         return ((uint32_t)osFlagsErrorParameter);
     }
 
-    set_flags = event_cb->event.set |= flags;
+    set_flags = event_cb->event.set | flags;
 
     result = rt_event_send(&(event_cb->event), flags);
 


### PR DESCRIPTION
- 事件标志设置由rtt函数内部保护后设置

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event flag handling to prevent unintended internal state mutations while maintaining proper return values and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->